### PR TITLE
Add needs keyword

### DIFF
--- a/.github/workflows/generate_publish_release.yml
+++ b/.github/workflows/generate_publish_release.yml
@@ -56,6 +56,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   Publish:
     runs-on: ubuntu-latest
+    needs: Generate
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
@@ -84,6 +85,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   Release:
     runs-on: ubuntu-latest
+    needs: Publish
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby


### PR DESCRIPTION
Add the `needs` keyword to the `publish` and `release` jobs to ensure we are running the jobs in the correct order.